### PR TITLE
fix(source/docs/场景应用/阅读理解): typo fix

### DIFF
--- a/source/docs/场景应用/阅读理解.md
+++ b/source/docs/场景应用/阅读理解.md
@@ -7,7 +7,7 @@ Understand and analyze the content of specified text data and answer the questio
 
 > [**Erlangshen-Ubert-110M-Chinese**](https://huggingface.co/IDEA-CCNL/Erlangshen-Ubert-110M-Chinese)：采用统一的框架处理多种抽取任务，AIWIN2022的冠军方案，1.1亿参数量的中文UBERT-Base。
 
-> [**Erlangshen-Ubert-330M-Chinese**](https://huggingface.co/IDEA-CCNL/Erlangshen-Ubert-330M-Chinese)：采用统一的框架处理多种抽取任务，AIWIN2022的冠军方案，1.1亿参数量的中文UBERT-Large。
+> [**Erlangshen-Ubert-330M-Chinese**](https://huggingface.co/IDEA-CCNL/Erlangshen-Ubert-330M-Chinese)：采用统一的框架处理多种抽取任务，AIWIN2022的冠军方案，3.3亿参数量的中文UBERT-Large。
 
 ## 使用 Usage
 


### PR DESCRIPTION
笔误更正：UBERT-Large 是 3.3 亿参数