### PR TITLE
更正pipline到pipeline，更正example，原example有typo，跑不通

### DIFF
--- a/source/docs/二郎神系列/Erlangshen-Ubert-110M-Chinese.md
+++ b/source/docs/二郎神系列/Erlangshen-Ubert-110M-Chinese.md
@@ -49,10 +49,10 @@ pip install --editable ./
 一键运行下面代码得到预测结果, 你可以任意修改示例 text 和要抽取的 entity_type，体验一下 Zero-Shot 性能
 ```python
 import argparse
-from fengshen import UbertPiplines
+from fengshen import UbertPipelines
 
 total_parser = argparse.ArgumentParser("TASK NAME")
-total_parser = UbertPiplines.piplines_args(total_parser)
+total_parser = UbertPipelines.pipelines_args(total_parser)
 args = total_parser.parse_args()
 args.pretrained_model_path = 'IDEA-CCNL/Erlangshen-Ubert-110M-Chinese'  #预训练模型路径
 test_data=[
@@ -67,7 +67,7 @@ test_data=[
         "id": 0}
 ]
 
-model = UbertPiplines(args)
+model = UbertPipelines(args)
 result = model.predict(test_data)
 for line in result:
     print(line)
@@ -99,7 +99,7 @@ for line in result:
 
 ### 数据预处理示例
 
-整个模型的 Piplines 我们已经写好，所以为了方便，我们定义了数据格式。目前我们在预训练中主要含有一下几种任务类型
+整个模型的 Pipelines 我们已经写好，所以为了方便，我们定义了数据格式。目前我们在预训练中主要含有一下几种任务类型
 
 | task_type | subtask_type   |
 |:---------:|:--------------:|

--- a/source/docs/二郎神系列/Erlangshen-Ubert-330M-Chinese.md
+++ b/source/docs/二郎神系列/Erlangshen-Ubert-330M-Chinese.md
@@ -49,10 +49,10 @@ Run the code
 
 ```python
 import argparse
-from fengshen import UbertPiplines
+from fengshen import UbertPipelines
 
 total_parser = argparse.ArgumentParser("TASK NAME")
-total_parser = UbertPiplines.piplines_args(total_parser)
+total_parser = UbertPipelines.pipelines_args(total_parser)
 args = total_parser.parse_args()
 
 args.pretrained_model_path = "IDEA-CCNL/Erlangshen-Ubert-330M-Chinese"
@@ -69,7 +69,7 @@ test_data=[
         "id": 0}
 ]
 
-model = UbertPiplines(args)
+model = UbertPipelines(args)
 result = model.predict(test_data)
 for line in result:
     print(line)
@@ -101,7 +101,7 @@ for line in result:
 
 ## 数据预处理示例
 
-整个模型的 Piplines 我们已经写好，所以为了方便，我们定义了数据格式。目前我们在预训练中主要含有一下几种任务类型
+整个模型的 Pipelines 我们已经写好，所以为了方便，我们定义了数据格式。目前我们在预训练中主要含有一下几种任务类型
 
 | task_type | subtask_type   |
 |:---------:|:--------------:|


### PR DESCRIPTION
Ubert的example中写的是``pipline``，但是代码中应该是``pipeline``，example中的代码是错的